### PR TITLE
Update admin path

### DIFF
--- a/src/signal_documentation/urls.py
+++ b/src/signal_documentation/urls.py
@@ -30,7 +30,7 @@ handler500 = InternalServerErrorView.as_view()
 
 
 urlpatterns = [
-    path("admin/", admin.site.urls),
+    path(f'{settings.MAIN_PAGE}/admin/' if settings.MAIN_PAGE else 'admin/', admin.site.urls),
     # signals
     path(
         f"{settings.MAIN_PAGE}/" if settings.MAIN_PAGE else "", include("signals.urls")


### PR DESCRIPTION
Allows prefixing the admin URL with MAIN_PAGE (when set).

For instance, if we have set MAIN_PAGE as "signals", the admin URL will be constructed as:

host/signals/admin...