### PR TITLE
Increase max upload body size

### DIFF
--- a/nginx/default.conf.template
+++ b/nginx/default.conf.template
@@ -18,5 +18,6 @@ server {
         proxy_set_header Host $http_host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-Proto $scheme;
+        client_max_body_size 64m;
     }
 }


### PR DESCRIPTION
CSV uploads are failing. This should allow for a greater upload size.

See: Issue https://github.com/cmu-delphi/signal-discovery/issues/13