### PR TITLE
Increase gunicorn timeouts

### DIFF
--- a/gunicorn/gunicorn.py
+++ b/gunicorn/gunicorn.py
@@ -2,3 +2,5 @@ import multiprocessing
 
 bind = "0.0.0.0:8000"
 workers = multiprocessing.cpu_count() * 2 + 1
+keepalive = 120
+timeout = 300


### PR DESCRIPTION
It looks like gunicorn is being killed due to default timeouts. Now that we are allowing larger uploads, and by extension longer wait times, we need to keep gunicorn alive for longer.